### PR TITLE
Return the promise at the end

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,4 +21,5 @@ module.exports = (options) => {
 
   const promise = donwloadFontello(config, { fontsDestDir, stylesDestDir });
   ora.promise(promise, { text: 'Downloading fontello font' });
+  return promise;
 };


### PR DESCRIPTION
This allows better flexibility when used programmatically, since you can just chain a `.then` statement at the end:

```js
fontellizr({
  // ...
}).then(() => {
  console.log('done!');
})
```